### PR TITLE
A simple TZX player, good enough for Breaking Baud

### DIFF
--- a/Amstrad.qsf
+++ b/Amstrad.qsf
@@ -283,6 +283,8 @@ set_global_assignment -name FITTER_EFFORT "STANDARD FIT"
 set_global_assignment -name SEED 1
 
 set_global_assignment -name STRATIX_DEVICE_IO_STANDARD "3.3-V LVTTL"
+set_global_assignment -name ENABLE_SIGNALTAP OFF
+set_global_assignment -name USE_SIGNALTAP_FILE output_files/cdt.stp
 set_global_assignment -name QIP_FILE sys/sys.qip
 set_global_assignment -name QIP_FILE t80/T80.qip
 set_global_assignment -name SYSTEMVERILOG_FILE u765.sv
@@ -299,4 +301,6 @@ set_global_assignment -name SYSTEMVERILOG_FILE Amstrad_GA.sv
 set_global_assignment -name VERILOG_FILE Amstrad_MMU.v
 set_global_assignment -name VERILOG_FILE Amstrad_motherboard.v
 set_global_assignment -name SYSTEMVERILOG_FILE Amstrad.sv
+set_global_assignment -name VHDL_FILE tap_fifo.vhd
+set_global_assignment -name VHDL_FILE tzxplayer.vhd
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/Amstrad.sv
+++ b/Amstrad.sv
@@ -61,6 +61,7 @@ localparam CONF_STR = {
 	"S1,DSK,Mount Disk B:;",
 	"F,E??,Load expansion;",
 	"F,CDT,Load;",
+	"OK,Tape sound,Disabled,Enabled;",
 	"O9A,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%;",
 	"OBD,Display,Color(GA),Color(ASIC),Green,Amber,Cyan,White;",
 	"O2,CRTC,Type 1,Type 0;",
@@ -652,12 +653,13 @@ assign VGA_VS = (forced_scandoubler & ~ypbpr) ? ~MVS : 1'b1;
 //////////////////////////////////////////////////////////////////////
 
 wire [7:0] audio_l, audio_r;
+wire       tape_sound = status[20];
 
 sigma_delta_dac #(7) dac_l
 (
 	.CLK(clk_sys & ce_16),
 	.RESET(reset),
-	.DACin(audio_l - audio_l[7:2] + {tape_rec, 5'd0}),
+	.DACin(audio_l - audio_l[7:2] + (tape_sound ? {tape_rec, tape_play, 4'd0} : 0)),
 	.DACout(AUDIO_L)
 );
 
@@ -665,7 +667,7 @@ sigma_delta_dac #(7) dac_r
 (
 	.CLK(clk_sys & ce_16),
 	.RESET(reset),
-	.DACin(audio_r - audio_r[7:2] + {tape_rec, 5'd0}),
+	.DACin(audio_r - audio_r[7:2] + (tape_sound ? {tape_rec, tape_play, 4'd0} : 0)),
 	.DACout(AUDIO_R)
 );
 

--- a/Amstrad.sv
+++ b/Amstrad.sv
@@ -60,6 +60,7 @@ localparam CONF_STR = {
 	"S0,DSK,Mount Disk A:;",
 	"S1,DSK,Mount Disk B:;",
 	"F,E??,Load expansion;",
+	"F,CDT,Load;",
 	"O9A,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%;",
 	"OBD,Display,Color(GA),Color(ASIC),Green,Amber,Cyan,White;",
 	"O2,CRTC,Type 1,Type 0;",
@@ -180,12 +181,18 @@ mist_io #(.STRLEN($size(CONF_STR)>>3)) mist_io
 	.ioctl_file_ext(ioctl_file_ext)
 );
 
-wire        rom_download = ioctl_download;
+wire        rom_download  = ioctl_download && (ioctl_index == 8'd0);
+wire        ext_download  = ioctl_download && (ioctl_index == 8'd3);
+wire        tape_download = ioctl_download && (ioctl_index == 8'd4);
 
 reg         boot_wr = 0;
 reg  [22:0] boot_a;
 reg   [1:0] boot_bank;
 reg   [7:0] boot_dout;
+
+reg  [22:0] tape_addr;
+reg         tape_wr = 0;
+reg         tape_ack;
 
 wire        rom_mask = ram_a[22] & (~rom_map[map_addr] | &{map_addr,status[15]});
 reg         rom_map[256] = '{default:0};
@@ -196,7 +203,8 @@ reg [8:0] page = 0;
 always @(posedge clk_sys) begin
 	reg combo = 0;
 	reg old_download;
-	reg old_wr;      
+	reg old_wr;
+	reg old_tape_ack;
 
 	old_wr <= ioctl_wr;
 	if(rom_download & old_wr & ~ioctl_wr) begin
@@ -208,7 +216,7 @@ always @(posedge clk_sys) begin
 	end
 
 	old_download <= ioctl_download;
-	if(~old_download & ioctl_download) begin
+	if(~old_download & ioctl_download & ext_download) begin
 		page <= 9'h1EE; // some unused page for malformed file extension
 		combo <= 0;
 		if(ioctl_file_ext[15:8] >= "0" && ioctl_file_ext[15:8] <= "9") page[7:4] <= ioctl_file_ext[11:8];
@@ -218,19 +226,30 @@ always @(posedge clk_sys) begin
 		if(ioctl_file_ext[15:0] == "ZZ") page <= 0;
 		if(ioctl_file_ext[15:0] == "Z0") begin page <= 0; combo <= 1; end
 	end
+
+	old_tape_ack <= tape_ack;
+	if(tape_download) begin
+		if(old_tape_ack ^ tape_ack) tape_wr <= 0;
+		if(~old_wr & ioctl_wr) tape_wr <= 1'b1;
+	end
 end
 
 always_comb begin
-	boot_wr = rom_download & ioctl_wr;
+	boot_wr = (rom_download | ext_download) & ioctl_wr;
 	boot_dout = ioctl_dout;
 
 	boot_a[13:0] = ioctl_addr[13:0];
 	boot_a[22:14] = '1;
+	boot_bank = 0;
+	tape_addr = 0;
 
-	if(ioctl_index) begin
+	if (tape_download) begin
+		tape_addr = ioctl_addr[22:0];
+	end
+	else if(ext_download) begin
 		boot_a[22]    = page[8];
 		boot_a[21:14] = page[7:0] + ioctl_addr[21:14];
-		boot_bank     = model;
+		boot_bank     = { 1'b0, model };
 	end
 	else begin
 		case(ioctl_addr[24:14])
@@ -272,12 +291,19 @@ sdram sdram
 	.oe  (reset ? 1'b0      : mem_rd & ~mf2_ram_en & ~rom_mask),
 	.we  (reset ? boot_wr   : mem_wr & ~mf2_ram_en & ~mf2_rom_en),
 	.addr(reset ? boot_a    : mf2_rom_en ? { 9'h1ff, cpu_addr[13:0] }: ram_a),
-	.bank(reset ? boot_bank : model),
+	.bank(reset ? boot_bank : { 1'b0, model } ),
 	.din (reset ? boot_dout : cpu_dout),
 	.dout(ram_dout),
 
 	.vram_addr({2'b10,vram_addr,1'b0}),
-	.vram_dout(vram_dout)
+	.vram_dout(vram_dout),
+
+	.tape_addr(tape_addr),
+	.tape_din(boot_dout),
+	.tape_dout(),
+	.tape_wr(tape_wr),
+	.tape_rd(),
+	.tape_ack(tape_ack)
 );
 
 reg model = 0;

--- a/YM2149.sv
+++ b/YM2149.sv
@@ -151,18 +151,13 @@ always @(posedge CLK) begin
 
 	if(CE) begin
 		if (ena_div_noise) begin
-			if(ymreg[6][4:0]) begin
-				if (noise_gen_cnt >= ymreg[6][4:0] - 1'd1) begin
-					noise_gen_cnt <= 0;
-					poly17 <= {(poly17[0] ^ poly17[2] ^ !poly17), poly17[16:1]};
-				end else begin
-					noise_gen_cnt <= noise_gen_cnt + 1'd1;
-				end
-				noise_gen_op <= {3{poly17[0]}};
-			end else begin
-				noise_gen_op <= ymreg[7][5:3];
+			if (!ymreg[6][4:0] || noise_gen_cnt >= ymreg[6][4:0] - 1'd1) begin
 				noise_gen_cnt <= 0;
+				poly17 <= {(poly17[0] ^ poly17[2] ^ !poly17), poly17[16:1]};
+			end else begin
+				noise_gen_cnt <= noise_gen_cnt + 1'd1;
 			end
+			noise_gen_op <= {3{poly17[0]}};
 		end
 	end
 end

--- a/tzxplayer.vhd
+++ b/tzxplayer.vhd
@@ -1,0 +1,270 @@
+---------------------------------------------------------------------------------
+-- TZX player
+-- by György Szombathelyi
+-- basic idea for the structure based on c1530 tap player by darfpga
+--
+---------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use IEEE.STD_LOGIC_ARITH.ALL;
+use ieee.std_logic_unsigned.all;
+use ieee.numeric_std.all;
+
+entity tzxplayer is
+generic (
+	TZX_MS : integer := 64000;   -- periods for one milliseconds
+	TZX_3M5_DIV : integer := 18  -- divide to 3.5 MHz
+);
+port(
+	clk             : in std_logic;
+	restart_tape    : in std_logic; -- keep to 1 to long enough to clear fifo
+	                                -- reset tap header bytes skip counter
+
+	host_tap_in     : in std_logic_vector(7 downto 0);  -- 8bits fifo input
+	host_tap_wrreq  : in std_logic;                     -- set to 1 for 1 clk to write 1 word
+	tap_fifo_wrfull : out std_logic;                    -- do not write when fifo tap_fifo_full = 1
+	tap_fifo_error  : out std_logic;                    -- fifo fall empty (unrecoverable error)
+
+	cass_read  : buffer std_logic;   -- tape read signal
+	cass_motor : in  std_logic    -- 1 = tape motor is powered
+);
+end tzxplayer;
+
+architecture struct of tzxplayer is
+
+signal tap_fifo_do    : std_logic_vector(7 downto 0);
+signal tap_fifo_rdreq : std_logic;
+signal tap_fifo_empty : std_logic;
+signal tick_cnt       : std_logic_vector( 5 downto 0);
+signal wave_cnt       : std_logic_vector(15 downto 0);
+signal wave_period    : std_logic;
+signal start_bytes    : std_logic_vector(7 downto 0);
+signal skip_bytes     : std_logic;
+signal playing        : std_logic;  -- 1 = tap or wav file is playing
+signal bit_cnt        : std_logic_vector(2 downto 0);
+
+type tzx_state_t is (
+	TZX_HEADER,
+	TZX_NEWBLOCK,
+	TZX_PAUSE,
+	TZX_PAUSE2,
+	TZX_TURBO,
+	TZX_PLAY_TONE,
+	TZX_PLAY_SYNC1,
+	TZX_PLAY_SYNC2,
+	TZX_PLAY_TAPBLOCK,
+	TZX_PLAY_TAPBLOCK2,
+	TZX_PLAY_TAPBLOCK3,
+	TZX_PLAY_TAPBLOCK4);
+
+signal tzx_state: tzx_state_t;
+
+signal tzx_offset     : std_logic_vector( 7 downto 0);
+signal pause_len      : std_logic_vector(15 downto 0);
+signal ms_counter     : std_logic_vector(15 downto 0);
+signal pilot_l        : std_logic_vector(15 downto 0);
+signal sync1_l        : std_logic_vector(15 downto 0);
+signal sync2_l        : std_logic_vector(15 downto 0);
+signal zero_l         : std_logic_vector(15 downto 0);
+signal one_l          : std_logic_vector(15 downto 0);
+signal pilot_pulses   : std_logic_vector(15 downto 0);
+signal last_byte_bits : std_logic_vector( 2 downto 0);
+signal data_len       : std_logic_vector(23 downto 0);
+signal pulse_len      : std_logic_vector(15 downto 0);
+
+begin
+-- for wav mode use large depth fifo (eg 512 x 32bits)
+-- for tap mode fifo may be smaller (eg 16 x 32bits)
+tap_fifo_inst : entity work.tap_fifo
+port map(
+	aclr	 => restart_tape,
+	data	 => host_tap_in,
+	clock	 => clk,
+	rdreq	 => tap_fifo_rdreq,
+	wrreq	 => host_tap_wrreq,
+	q	     => tap_fifo_do,
+	empty	 => tap_fifo_empty,
+	full	 => tap_fifo_wrfull
+);
+
+process(clk, restart_tape)
+begin
+
+	if restart_tape = '1' then
+
+		start_bytes <= X"00";
+		tzx_state <= TZX_HEADER;
+		pulse_len <= (others => '0');
+		tick_cnt <= (others => '0');
+		wave_cnt <= (others => '0');
+		wave_period <= '0';
+		playing <= '0';
+
+		tap_fifo_rdreq <='0';
+		tap_fifo_error <='0'; -- run out of data
+
+	elsif rising_edge(clk) then
+
+		playing <= cass_motor;
+
+		if playing = '0' then
+			--cass_read <= '1';
+		end if;	
+
+		if playing = '1' and pulse_len /= 0 then
+			tick_cnt <= tick_cnt + 1;
+			if tick_cnt = TZX_3M5_DIV - 1 then
+				tick_cnt <= (others => '0');
+				wave_cnt <= wave_cnt + 1;
+				if wave_cnt = pulse_len then
+					wave_cnt <= (others => '0');
+					cass_read <= wave_period;
+					if wave_period = '1' then
+						pulse_len <= (others => '0');
+						wave_period <= '0';
+					else
+						wave_period <= '1';
+					end if;
+				end if;
+			end if;
+		end if;
+
+		tap_fifo_rdreq <= '0';
+
+		if playing = '1' and pulse_len = 0 then
+
+			wave_cnt <= (others => '0');
+
+			if tap_fifo_empty = '1' then
+				tap_fifo_error <= '1';
+			else
+				tap_fifo_rdreq <= '1';
+			end if;
+
+			case tzx_state is
+			when TZX_HEADER =>
+				cass_read <= '1';
+				if start_bytes < X"0A" then
+					start_bytes <= start_bytes + 1;
+				else
+					tzx_state <= TZX_NEWBLOCK;
+				end if;
+
+			when TZX_NEWBLOCK =>
+				tzx_offset <= (others=>'0');
+				ms_counter <= (others=>'0');
+
+				case tap_fifo_do is
+				when x"20" => tzx_state <= TZX_PAUSE;
+				when x"11" => tzx_state <= TZX_TURBO;
+				when others => null;
+				end case;
+
+			when TZX_PAUSE =>
+				tzx_offset <= tzx_offset + 1;
+				if tzx_offset = x"00" then 
+					tap_fifo_rdreq <= '0';
+					pause_len(7 downto 0) <= tap_fifo_do;
+				elsif tzx_offset = x"01" then
+					pause_len(15 downto 8) <= tap_fifo_do;
+					tzx_state <= TZX_PAUSE2;
+				end if;
+
+			when TZX_PAUSE2 =>
+				tap_fifo_rdreq <= '0';
+				if ms_counter /= 0 then ms_counter <= ms_counter - 1;
+				elsif pause_len /= 0 then
+					pause_len <= pause_len - 1;
+					ms_counter <= conv_std_logic_vector(TZX_MS, 16);
+				else
+					tap_fifo_rdreq <= '1';
+					tzx_state <= TZX_NEWBLOCK;
+				end if;
+
+			when TZX_TURBO =>
+				tzx_offset <= tzx_offset + 1;
+				if    tzx_offset = x"00" then pilot_l( 7 downto  0) <= tap_fifo_do;
+				elsif tzx_offset = x"01" then pilot_l(15 downto  8) <= tap_fifo_do;
+				elsif tzx_offset = x"02" then sync1_l( 7 downto  0) <= tap_fifo_do;
+				elsif tzx_offset = x"03" then sync1_l(15 downto  8) <= tap_fifo_do;
+				elsif tzx_offset = x"04" then sync2_l( 7 downto  0) <= tap_fifo_do;
+				elsif tzx_offset = x"05" then sync2_l(15 downto  8) <= tap_fifo_do;
+				elsif tzx_offset = x"06" then zero_l ( 7 downto  0) <= tap_fifo_do;
+				elsif tzx_offset = x"07" then zero_l (15 downto  8) <= tap_fifo_do;
+				elsif tzx_offset = x"08" then one_l  ( 7 downto  0) <= tap_fifo_do;
+				elsif tzx_offset = x"09" then one_l  (15 downto  8) <= tap_fifo_do;
+				elsif tzx_offset = x"0A" then pilot_pulses( 7 downto  0) <= tap_fifo_do;
+				elsif tzx_offset = x"0B" then pilot_pulses(15 downto  8) <= tap_fifo_do;
+				elsif tzx_offset = x"0C" then last_byte_bits <= tap_fifo_do(2 downto 0);
+				elsif tzx_offset = x"0D" then pause_len( 7 downto  0) <= tap_fifo_do;
+				elsif tzx_offset = x"0E" then pause_len(15 downto  8) <= tap_fifo_do;
+				elsif tzx_offset = x"0F" then data_len ( 7 downto  0) <= tap_fifo_do;
+				elsif tzx_offset = x"10" then data_len (15 downto  8) <= tap_fifo_do;
+				elsif tzx_offset = x"11" then
+					tap_fifo_rdreq <= '0';
+					data_len (23 downto 16) <= tap_fifo_do;
+					tzx_state <= TZX_PLAY_TONE;
+				end if;
+
+			when TZX_PLAY_TONE =>
+				tap_fifo_rdreq <= '0';
+				pulse_len <= pilot_l;
+				if pilot_pulses /= 0 then
+					pilot_pulses <= pilot_pulses - 1;
+				else
+					tzx_state <= TZX_PLAY_SYNC1;
+				end if;
+
+			when TZX_PLAY_SYNC1 =>
+				tap_fifo_rdreq <= '0';
+				pulse_len <= sync1_l;
+				if sync1_l = sync2_l then
+					tzx_state <= TZX_PLAY_TAPBLOCK;
+				else
+					tzx_state <= TZX_PLAY_SYNC2;
+				end if;
+
+			when TZX_PLAY_SYNC2 =>
+				tap_fifo_rdreq <= '0';
+				pulse_len <= sync2_l;
+				tzx_state <= TZX_PLAY_TAPBLOCK;
+
+			when TZX_PLAY_TAPBLOCK =>
+				tap_fifo_rdreq <= '0';
+				bit_cnt <= "111";
+				tzx_state <= TZX_PLAY_TAPBLOCK2;
+
+			when TZX_PLAY_TAPBLOCK2 =>
+				tap_fifo_rdreq <= '0';
+				bit_cnt <= bit_cnt - 1;
+				if bit_cnt = "000" then 
+					data_len <= data_len - 1;
+					tzx_state <= TZX_PLAY_TAPBLOCK3;
+				end if;
+				if tap_fifo_do(CONV_INTEGER(bit_cnt)) = '0' then
+					pulse_len <= zero_l;
+				else
+					pulse_len <= one_l;
+				end if;
+
+			when TZX_PLAY_TAPBLOCK3 =>
+				if data_len = 0 then
+					tzx_state <= TZX_PAUSE2;
+				else
+					tzx_state <= TZX_PLAY_TAPBLOCK4;
+				end if;
+
+			when TZX_PLAY_TAPBLOCK4 =>
+				tap_fifo_rdreq <= '0';
+				tzx_state <= TZX_PLAY_TAPBLOCK2;
+
+			when others => null;
+			end case;
+
+		end if; -- play tzx
+
+	end if; -- clk
+end process;
+
+end struct;


### PR DESCRIPTION
Only TZX block type 0x11 and 0x20 are implemented, but 5 out of 5 CDTs don't contain others. It's easy to add missing types.